### PR TITLE
Add test for `db` command and support for `application/mp4` mime type

### DIFF
--- a/src/file_type.rs
+++ b/src/file_type.rs
@@ -89,6 +89,7 @@ pub(crate) fn file_type_from_content_type(ct: &str) -> AccurateFileType {
         "image/png" => AccurateFileType::Png,
         "image/heic" => AccurateFileType::Heic,
         "video/mp4" => AccurateFileType::Mp4,
+        "application/mp4" => AccurateFileType::Mp4,
         "video/mov" => AccurateFileType::Mov,
         "video/quicktime" => AccurateFileType::Mp4,
         "application/octet-stream" => AccurateFileType::Unsupported,


### PR DESCRIPTION
- Refactored `src/db_cmd.rs` to extract `run_db_scan` function, making it testable.
- Added `test_db_scan` in `src/db_cmd.rs` to verify files in `test` directory are indexed correctly.
- Added support for `application/mp4` mime type in `src/file_type.rs` to correctly identify MP4 files that report this mime type.

---
*PR created automatically by Jules for task [10748372600345314269](https://jules.google.com/task/10748372600345314269) started by @paultuckey*