### PR TITLE
Fix unused constant warning in src/db_cmd.rs

### DIFF
--- a/src/db_cmd.rs
+++ b/src/db_cmd.rs
@@ -162,6 +162,7 @@ const DB_MEDIA_ITEM_INSERT: &str = "
         accurate_file_type, media_info, guessed_datetime, modified_at, created_at)
     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
 ";
+#[allow(dead_code)]
 const DB_MEDIA_ITEM_SELECT_ALL: &str = "
     SELECT media_path, long_hash, short_hash, quick_file_type,
         accurate_file_type, media_info, guessed_datetime, modified_at, created_at


### PR DESCRIPTION
Suppressed an unused constant warning in `src/db_cmd.rs` by adding `#[allow(dead_code)]`. The constant `DB_MEDIA_ITEM_SELECT_ALL` is used in an ignored test case and might be useful for future development. verified with `cargo clippy` and `cargo test`.

---
*PR created automatically by Jules for task [18231521903172112905](https://jules.google.com/task/18231521903172112905) started by @paultuckey*