### PR TITLE
Refactor timestamp conversion to helper function

### DIFF
--- a/src/media.rs
+++ b/src/media.rs
@@ -130,13 +130,13 @@ pub(crate) fn best_guess_taken_dt(info: &MediaFileInfo) -> Option<String> {
         return Some(dt);
     }
     if let Some(dt) = info.created {
-        let o = DateTime::from_timestamp_millis(dt).map(|d| d.to_rfc3339());
+        let o = crate::util::timestamp_to_rfc3339(dt);
         if let Some(dt) = o {
             return Some(dt);
         }
     }
     if let Some(dt) = info.modified {
-        let o = DateTime::from_timestamp_millis(dt).map(|d| d.to_rfc3339());
+        let o = crate::util::timestamp_to_rfc3339(dt);
         if let Some(dt) = o {
             return Some(dt);
         }
@@ -181,6 +181,25 @@ pub(crate) fn get_desired_media_path(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_best_guess_taken_dt_timestamps() {
+        let mut info = MediaFileInfo::new_for_test();
+        // 1000000000000 ms = 2001-09-09T01:46:40Z
+        let ts = 1000000000000;
+
+        // Test created timestamp
+        info.created = Some(ts);
+        info.modified = None;
+        let dt = best_guess_taken_dt(&info).expect("Should have a date from created");
+        assert_eq!(dt, "2001-09-09T01:46:40+00:00");
+
+        // Test modified timestamp
+        info.created = None;
+        info.modified = Some(ts);
+        let dt = best_guess_taken_dt(&info).expect("Should have a date from modified");
+        assert_eq!(dt, "2001-09-09T01:46:40+00:00");
+    }
 
     #[test]
     fn test_desired_media_path() -> anyhow::Result<()> {
@@ -232,6 +251,7 @@ impl MediaFileInfo {
         }
     }
 }
+
 
 #[cfg(test)]
 impl MediaFileDerivedInfo {

--- a/src/supplemental_info.rs
+++ b/src/supplemental_info.rs
@@ -1,5 +1,4 @@
 use crate::util::PsContainer;
-use chrono::DateTime;
 use serde::{Deserialize, Serialize};
 use std::io::Read;
 use tracing::{debug, warn};
@@ -60,9 +59,9 @@ impl SupplementalInfoDateTime {
         {
             if ts.len() == 10 {
                 // seconds to milliseconds
-                return DateTime::from_timestamp_millis(ts_i64 * 1000).map(|d| d.to_rfc3339());
+                return crate::util::timestamp_to_rfc3339(ts_i64 * 1000);
             }
-            return DateTime::from_timestamp_millis(ts_i64).map(|d| d.to_rfc3339());
+            return crate::util::timestamp_to_rfc3339(ts_i64);
         }
         None
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 use crate::db_cmd::HashInfo;
 use crate::file_type::{QuickFileType, find_quick_file_type};
 use anyhow::anyhow;
+use chrono::DateTime;
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::fs::File;
@@ -358,6 +359,10 @@ pub(crate) fn name_part(file_path_s: &String) -> String {
         return "@@broken".to_string();
     };
     file_name_str.to_string_lossy().to_string()
+}
+
+pub(crate) fn timestamp_to_rfc3339(ts: i64) -> Option<String> {
+    DateTime::from_timestamp_millis(ts).map(|d| d.to_rfc3339())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR refactors the timestamp conversion logic in `src/media.rs` and `src/supplemental_info.rs` to use a new helper function `timestamp_to_rfc3339` in `src/util.rs`.

**What:**
- Added `timestamp_to_rfc3339` to `src/util.rs`.
- Replaced duplicated code in `src/media.rs`.
- Replaced duplicated code in `src/supplemental_info.rs`.
- Added a test case in `src/media.rs` to verify the behavior.

**Why:**
- Reduces code duplication.
- Improves maintainability by centralizing the timestamp conversion logic.
- Ensures consistency across the codebase.

**Verification:**
- Ran `cargo test` and all tests passed.
- Verified that the new helper function correctly converts timestamps to RFC3339 strings.

---
*PR created automatically by Jules for task [15880549465199604067](https://jules.google.com/task/15880549465199604067) started by @paultuckey*