### PR TITLE
Refactor markdown assembly return type

### DIFF
--- a/src/info_cmd.rs
+++ b/src/info_cmd.rs
@@ -52,7 +52,7 @@ pub(crate) fn media(si: &ScanInfo, root: &mut Box<dyn PsContainer>) -> anyhow::R
 
     println!("Markdown:");
     let mfm = mfm_from_media_file_info(&media_file_info);
-    let s = assemble_markdown(&mfm, &None, "")?;
+    let s = assemble_markdown(&mfm, &None, "")?.into_string();
     println!("{s}");
     println!();
 

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -52,9 +52,11 @@ pub(crate) fn sync_markdown(
         e_yaml = Some(e_yaml_i);
         e_md = e_md_i;
     }
-    let md_str = assemble_markdown(&mfm, &e_yaml, &e_md)?;
-    let md_bytes = md_str.as_bytes().to_vec();
-    output_c.write(dry_run, &output_path, Cursor::new(&md_bytes));
+    let md_res = assemble_markdown(&mfm, &e_yaml, &e_md)?;
+    if let AssembledMarkdown::Modified(md_str) = md_res {
+        let md_bytes = md_str.as_bytes().to_vec();
+        output_c.write(dry_run, &output_path, Cursor::new(&md_bytes));
+    }
     Ok(())
 }
 
@@ -144,29 +146,42 @@ pub(crate) fn split_frontmatter(file_contents: &str) -> (String, String) {
     ("".to_string(), file_contents.to_string())
 }
 
+pub(crate) enum AssembledMarkdown {
+    Modified(String),
+    Unchanged(String),
+}
+
+impl AssembledMarkdown {
+    pub(crate) fn into_string(self) -> String {
+        match self {
+            AssembledMarkdown::Modified(s) => s,
+            AssembledMarkdown::Unchanged(s) => s,
+        }
+    }
+}
+
 pub(crate) fn assemble_markdown(
     mfm: &PhotoSorterFrontMatter,
     existing_yaml: &Option<String>,
     markdown_content: &str,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<AssembledMarkdown> {
     let new_yaml = merge_yaml(existing_yaml, mfm);
     if new_yaml.is_empty() {
         warn!("Generated YAML is empty, returning markdown content");
-        return Ok(markdown_content.to_string());
+        return Ok(AssembledMarkdown::Unchanged(markdown_content.to_string()));
     }
     if let Some(existing_yaml) = existing_yaml
         && new_yaml.eq(existing_yaml)
     {
         warn!("Generated YAML matches existing, returning original content");
-        // todo: better return type
-        return Ok(markdown_content.to_string());
+        return Ok(AssembledMarkdown::Unchanged(markdown_content.to_string()));
     }
     let mut s = String::new();
     s.push_str("---\n");
     s.push_str(&new_yaml);
     s.push_str("---\n");
     s.push_str(markdown_content);
-    Ok(s)
+    Ok(AssembledMarkdown::Modified(s))
 }
 
 fn merge_yaml(s: &Option<String>, fm: &PhotoSorterFrontMatter) -> String {


### PR DESCRIPTION
This refactor improves the `assemble_markdown` function by providing a return type that explicitly indicates whether the markdown content was modified. This allows callers, like `sync_markdown`, to avoid unnecessary file writes when the content remains unchanged. All relevant call sites have been updated to accommodate the new API.

---
*PR created automatically by Jules for task [12166971287150201480](https://jules.google.com/task/12166971287150201480) started by @paultuckey*