### PR TITLE
Standardize File System Abstraction with FileSystem Trait

### DIFF
--- a/src/exif_util.rs
+++ b/src/exif_util.rs
@@ -134,14 +134,14 @@ pub(crate) fn best_guess_taken_exif(exif: &Option<PsExifInfo>) -> Option<String>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::PsContainer;
-    use crate::util::PsDirectoryContainer;
+    use crate::fs::FileSystem;
+    use crate::fs::OsFileSystem;
 
     #[test]
     fn test_parse_exif_mp4() -> anyhow::Result<()> {
         crate::test_util::setup_log();
-        let mut c = PsDirectoryContainer::new(&"test".to_string());
-        let reader = c.file_reader(&"Hello.mp4".to_string())?;
+        let mut c = OsFileSystem::new(&"test".to_string());
+        let reader = c.open(&"Hello.mp4".to_string())?;
         let t = parse_exif_info(reader);
         assert_eq!(t.is_none(), true);
         Ok(())
@@ -150,8 +150,8 @@ mod tests {
     #[test]
     fn test_parse_exif_all_tags() -> anyhow::Result<()> {
         crate::test_util::setup_log();
-        let mut c = PsDirectoryContainer::new("test");
-        let reader = c.file_reader("Canon_40D.jpg")?;
+        let mut c = OsFileSystem::new("test");
+        let reader = c.open("Canon_40D.jpg")?;
         let t = parse_exif_info(reader).unwrap().tags;
         assert_eq!(t.len(), 40);
         let mut tag_names: Vec<String> = t.iter().map(|(t, _)| t.to_string()).collect();

--- a/src/file_type.rs
+++ b/src/file_type.rs
@@ -128,7 +128,7 @@ pub(crate) fn determine_file_type<R: Read + Seek>(reader: R, name: &String) -> A
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::PsContainer;
+    use crate::fs::FileSystem;
     use std::io::Cursor;
 
     #[test]
@@ -163,10 +163,10 @@ mod tests {
     #[test]
     fn test_accurate_file_type() {
         crate::test_util::setup_log();
-        use crate::util::PsDirectoryContainer;
+        use crate::fs::OsFileSystem;
         let name = "Canon_40D.jpg".to_string();
-        let mut root = PsDirectoryContainer::new(&"test".to_string());
-        let r = root.file_reader(&name).unwrap();
+        let mut root = OsFileSystem::new(&"test".to_string());
+        let r = root.open(&name).unwrap();
         assert_eq!(determine_file_type(r, &name), AccurateFileType::Jpg);
 
         let bad: Vec<u8> = vec![];

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,0 +1,248 @@
+use anyhow::{anyhow, Result};
+use chrono::{Datelike, FixedOffset, Timelike};
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::io::{Cursor, Read, Seek};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use tracing::{debug, error};
+use zip::ZipArchive;
+
+pub trait ReadSeek: Read + Seek {}
+impl<T: Read + Seek> ReadSeek for T {}
+
+#[derive(Debug, Clone)]
+pub struct FileMetadata {
+    pub len: u64,
+    pub is_dir: bool,
+    pub modified: Option<i64>,
+    pub created: Option<i64>,
+}
+
+pub trait FileSystem {
+    fn open(&mut self, path: &str) -> Result<Box<dyn ReadSeek>>;
+    fn exists(&self, path: &str) -> bool;
+    // Walk returns all files recursively as relative paths
+    fn walk(&self) -> Vec<String>;
+    fn metadata(&self, path: &str) -> Result<FileMetadata>;
+}
+
+#[derive(Debug, Clone)]
+pub struct OsFileSystem {
+    root: PathBuf,
+}
+
+impl OsFileSystem {
+    pub fn new(root: &str) -> Self {
+        Self {
+            root: PathBuf::from(root),
+        }
+    }
+
+    pub fn root_exists(&self) -> bool {
+        self.root.exists()
+    }
+
+    pub fn write<R: Read>(&self, dry_run: bool, path: &str, mut reader: R) {
+        let p = self.root.join(path);
+        if dry_run {
+            debug!("Dry run: would write file {:?}", p);
+            return;
+        }
+        if let Err(e) = fs::create_dir_all(p.parent().unwrap()) {
+            error!("Unable to create directory {:?}: {}", p.parent(), e);
+            return;
+        }
+        let mut file = match File::create(&p) {
+            Ok(f) => f,
+            Err(e) => {
+                error!("Unable to create file {p:?}: {e}");
+                return;
+            }
+        };
+        if let Err(e) = std::io::copy(&mut reader, &mut file) {
+            error!("Unable to write file {p:?}: {e}");
+            return;
+        }
+        debug!("Wrote file {p:?}");
+    }
+
+    pub fn set_modified(&self, dry_run: bool, path: &str, modified_datetime: &Option<i64>) {
+        let p = self.root.join(path);
+        let Some(dt) = modified_datetime else {
+            return;
+        };
+        let st = SystemTime::UNIX_EPOCH
+            .checked_add(Duration::from_millis(*dt as u64))
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        if dry_run {
+            debug!(
+                "  Dry run: would set modified datetime for file {p:?} to {dt}"
+            );
+            return;
+        }
+        let f_r = File::open(&p);
+        let Ok(f) = f_r else {
+            error!("Unable to open file {p:?} for setting modified datetime ");
+            return;
+        };
+        if let Err(e) = f.set_modified(st) {
+            error!("Unable to set modified datetime for file {p:?}: {e}");
+        } else {
+            debug!("Set modified datetime for file {p:?} to {dt}");
+        }
+    }
+}
+
+impl FileSystem for OsFileSystem {
+    fn open(&mut self, path: &str) -> Result<Box<dyn ReadSeek>> {
+        let p = self.root.join(path);
+        let f = File::open(&p).map_err(|e| anyhow!("Unable to open file {:?}: {}", p, e))?;
+        Ok(Box::new(f))
+    }
+
+    fn exists(&self, path: &str) -> bool {
+        self.root.join(path).exists()
+    }
+
+    fn walk(&self) -> Vec<String> {
+        let mut files = Vec::new();
+        if !self.root.exists() || !self.root.is_dir() {
+            return files;
+        }
+        scan_dir_recursively(&mut files, &self.root, &self.root);
+        files
+    }
+
+    fn metadata(&self, path: &str) -> Result<FileMetadata> {
+        let p = self.root.join(path);
+        let m = fs::metadata(&p)?;
+        Ok(FileMetadata {
+            len: m.len(),
+            is_dir: m.is_dir(),
+            modified: m
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+                .map(|d| d.as_millis() as i64),
+            created: m
+                .created()
+                .ok()
+                .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+                .map(|d| d.as_millis() as i64),
+        })
+    }
+}
+
+fn scan_dir_recursively(files: &mut Vec<String>, dir_path: &Path, root_path: &Path) {
+    if !dir_path.exists() || !dir_path.is_dir() {
+        return;
+    }
+    let Ok(dir_reader) = fs::read_dir(dir_path) else {
+        debug!("Unable to read directory: {dir_path:?}");
+        return;
+    };
+    for dir_entry in dir_reader {
+        let Ok(dir_entry) = dir_entry else {
+            continue;
+        };
+        let path = dir_entry.path();
+        if path.is_file() {
+            // trim root path from the file path
+            let relative_path = path.strip_prefix(root_path).unwrap_or(&path);
+            files.push(relative_path.to_string_lossy().to_string());
+        } else if path.is_dir() {
+            scan_dir_recursively(files, &path, root_path);
+        }
+    }
+}
+
+pub struct ZipFileSystem {
+    zip_file: String,
+    zip: ZipArchive<File>,
+    tz: FixedOffset,
+    file_names: Vec<String>,
+    metadata_cache: HashMap<String, FileMetadata>,
+}
+
+impl ZipFileSystem {
+    pub fn new(zip_file: &str, tz: FixedOffset) -> Result<Self> {
+        let f = File::open(zip_file)?;
+        let mut zip = ZipArchive::new(f)?;
+        let mut file_names = Vec::new();
+        let mut metadata_cache = HashMap::new();
+
+        for i in 0..zip.len() {
+            let Ok(file) = zip.by_index(i) else {
+                continue;
+            };
+            if file.is_dir() {
+                continue;
+            }
+            let Some(enclosed_name) = file.enclosed_name() else {
+                continue;
+            };
+            let Some(name) = enclosed_name.to_str() else {
+                continue;
+            };
+            let name_s = name.to_string();
+            file_names.push(name_s.clone());
+
+            let mut modified = None;
+            if let Some(lm) = file.last_modified() {
+                modified = chrono::NaiveDate::from_ymd_opt(
+                    lm.year() as i32,
+                    lm.month() as u32,
+                    lm.day() as u32,
+                )
+                .and_then(|date| date.and_hms_opt(lm.hour() as u32, lm.minute() as u32, 0))
+                .and_then(|naive_dt| naive_dt.and_local_timezone(tz).single())
+                .map(|dt| dt.timestamp_millis());
+            }
+
+            metadata_cache.insert(
+                name_s,
+                FileMetadata {
+                    len: file.size(),
+                    is_dir: false,
+                    modified,
+                    created: None,
+                },
+            );
+        }
+        Ok(Self {
+            zip_file: zip_file.to_string(),
+            zip,
+            tz,
+            file_names,
+            metadata_cache,
+        })
+    }
+}
+
+impl FileSystem for ZipFileSystem {
+    fn open(&mut self, path: &str) -> Result<Box<dyn ReadSeek>> {
+        let mut file = self
+            .zip
+            .by_name(path)
+            .map_err(|_| anyhow!("File not found in zip: {}", path))?;
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer)?;
+        Ok(Box::new(Cursor::new(buffer)))
+    }
+
+    fn exists(&self, path: &str) -> bool {
+        self.metadata_cache.contains_key(path)
+    }
+
+    fn walk(&self) -> Vec<String> {
+        self.file_names.clone()
+    }
+
+    fn metadata(&self, path: &str) -> Result<FileMetadata> {
+        self.metadata_cache
+            .get(path)
+            .cloned()
+            .ok_or_else(|| anyhow!("File not found in zip metadata cache: {}", path))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod album;
 mod db_cmd;
 mod exif_util;
 mod file_type;
+mod fs;
 mod index_cmd;
 mod info_cmd;
 mod markdown;

--- a/src/supplemental_info.rs
+++ b/src/supplemental_info.rs
@@ -1,11 +1,11 @@
-use crate::util::PsContainer;
+use crate::fs::FileSystem;
 use serde::{Deserialize, Serialize};
 use std::io::Read;
 use tracing::{debug, warn};
 
 pub(crate) fn detect_supplemental_info(
     path: &String,
-    container: &mut Box<dyn PsContainer>,
+    container: &mut Box<dyn FileSystem>,
 ) -> Option<String> {
     let google_supp_json_exts = vec![
         ".supplemental-metadata.json",
@@ -23,9 +23,9 @@ pub(crate) fn detect_supplemental_info(
 
 pub(crate) fn load_supplemental_info(
     path: &String,
-    container: &mut Box<dyn PsContainer>,
+    container: &mut Box<dyn FileSystem>,
 ) -> Option<PsSupplementalInfo> {
-    let reader_r = container.file_reader(path);
+    let reader_r = container.open(path);
     let Ok(reader) = reader_r else {
         warn!("Could not read supplemental json file: {path}");
         return None;

--- a/src/track_util.rs
+++ b/src/track_util.rs
@@ -90,14 +90,15 @@ fn parse_to_o_s(opt: &Option<&nom_exif::EntryValue>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::{PsContainer, PsDirectoryContainer};
+    use crate::fs::{FileSystem, OsFileSystem};
+    use crate::util::scan_fs;
     use std::path::Path;
 
     #[test]
     fn test_parse_track() -> anyhow::Result<()> {
         crate::test_util::setup_log();
-        let mut c = PsDirectoryContainer::new(&"test".to_string());
-        let reader = c.file_reader(&"Hello.mp4".to_string())?;
+        let mut c = OsFileSystem::new(&"test".to_string());
+        let reader = c.open(&"Hello.mp4".to_string())?;
         let meta = parse_track_info(reader).unwrap();
         assert_eq!(meta.width, Some(854));
         assert_eq!(meta.height, Some(480));
@@ -114,14 +115,14 @@ mod tests {
     #[ignore]
     fn test_all_mp4s() -> anyhow::Result<()> {
         crate::test_util::setup_log();
-        let mut c = PsDirectoryContainer::new(&"input".to_string());
-        for si in c.scan() {
+        let mut c = OsFileSystem::new(&"input".to_string());
+        for si in scan_fs(&mut c) {
             let path = Path::new(&si.file_path);
             if path
                 .extension()
                 .map_or(false, |ext| ext.eq_ignore_ascii_case("mp4"))
             {
-                let reader = c.file_reader(&path.to_string_lossy().to_string())?;
+                let reader = c.open(&path.to_string_lossy().to_string())?;
                 let _ = parse_track_info(reader);
             }
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,18 +1,18 @@
 use crate::db_cmd::HashInfo;
-use crate::file_type::{QuickFileType, find_quick_file_type};
-use anyhow::anyhow;
+use crate::file_type::{find_quick_file_type, QuickFileType};
+use crate::fs::{FileSystem, OsFileSystem, ZipFileSystem};
+use anyhow::Result;
 use chrono::DateTime;
 use sha2::{Digest, Sha256};
-use std::fs;
-use std::fs::File;
-use std::io::{Cursor, Read, Seek};
+use std::io::Read;
 use std::path::Path;
-use std::time::{Duration, SystemTime};
-use tracing::{debug, error, warn};
-use zip::ZipArchive;
+use tracing::{debug, warn};
+
+// Re-export ReadSeek for convenience if needed, or consumers can use fs::ReadSeek
+pub use crate::fs::ReadSeek;
 
 /// Similar to github generate a short and long hash from the bytes
-pub(crate) fn checksum_bytes<R: Read>(mut reader: R) -> anyhow::Result<HashInfo> {
+pub(crate) fn checksum_bytes<R: Read>(mut reader: R) -> Result<HashInfo> {
     let mut hasher = Sha256::new();
     let mut buffer = [0; 8192]; // Read in 8KB chunks
     loop {
@@ -29,17 +29,6 @@ pub(crate) fn checksum_bytes<R: Read>(mut reader: R) -> anyhow::Result<HashInfo>
         short_checksum: chars.clone().take(7).collect(),
         long_checksum: chars.take(64).collect(),
     })
-}
-
-pub(crate) trait ReadSeek: Read + Seek {}
-impl<T: Read + Seek> ReadSeek for T {}
-
-pub(crate) trait PsContainer {
-    fn scan(&self) -> Vec<ScanInfo>;
-    fn file_bytes(&mut self, path: &str) -> anyhow::Result<Vec<u8>>;
-    fn file_reader(&mut self, path: &str) -> anyhow::Result<Box<dyn ReadSeek>>;
-    fn exists(&self, path: &str) -> bool;
-    fn root_exists(&self) -> bool;
 }
 
 #[derive(Debug, Clone)]
@@ -68,269 +57,26 @@ impl ScanInfo {
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct PsDirectoryContainer {
-    root: String,
-}
-
-impl PsDirectoryContainer {
-    pub(crate) fn new(root: &str) -> Self {
-        PsDirectoryContainer {
-            root: root.to_string(),
-        }
-    }
-    pub(crate) fn write<R: Read>(&self, dry_run: bool, path: &String, reader: R) {
-        let p = Path::new(&self.root).join(path);
-        if dry_run {
-            debug!("Dry run: would write file {:?}", p);
-            return;
-        }
-        if let Err(e) = fs::create_dir_all(p.parent().unwrap()) {
-            error!("Unable to create directory {:?}: {}", p.parent(), e);
-            return;
-        }
-        let mut file = match File::create(&p) {
-            Ok(f) => f,
-            Err(e) => {
-                error!("Unable to create file {p:?}: {e}");
-                return;
-            }
+pub(crate) fn scan_fs(fs: &mut dyn FileSystem) -> Vec<ScanInfo> {
+    let paths = fs.walk();
+    let mut scan_infos = Vec::new();
+    for path in paths {
+        let meta = fs.metadata(&path).ok();
+        let (mod_dt, create_dt) = match meta {
+            Some(m) => (m.modified, m.created),
+            None => (None, None),
         };
-        if let Err(e) = std::io::copy(&mut reader.take(u64::MAX), &mut file) {
-            error!("Unable to write file {p:?}: {e}");
-            return;
-        }
-        debug!("Wrote file {p:?}");
+        scan_infos.push(ScanInfo::new(path, mod_dt, create_dt));
     }
-
-    pub(crate) fn set_modified(
-        &self,
-        dry_run: bool,
-        path: &String,
-        modified_datetime: &Option<i64>,
-    ) {
-        let p = Path::new(&self.root).join(path);
-        let Some(dt) = modified_datetime else {
-            return;
-        };
-        let st = SystemTime::UNIX_EPOCH
-            .checked_add(Duration::from_millis(*dt as u64))
-            .unwrap_or(SystemTime::UNIX_EPOCH);
-        if dry_run {
-            debug!("  Dry run: would set modified datetime for file {p:?} to {dt}");
-            return;
-        }
-        let f_r = File::open(&p);
-        let Ok(f) = f_r else {
-            error!("Unable to open file {p:?} for setting modified datetime ");
-            return;
-        };
-        if let Err(e) = f.set_modified(st) {
-            error!("Unable to set modified datetime for file {p:?}: {e}");
-        } else {
-            debug!("Set modified datetime for file {p:?} to {dt}");
-        }
-    }
-}
-
-/// Recursively scans the directory and its subdirectories,
-fn scan_dir_recursively(files: &mut Vec<ScanInfo>, dir_path: &Path, root_path: &Path) {
-    if !dir_path.exists() || !dir_path.is_dir() {
-        return;
-    }
-    let Ok(dir_reader) = fs::read_dir(dir_path) else {
-        debug!("Unable to read directory: {dir_path:?}");
-        return;
-    };
-    for dir_entry in dir_reader {
-        let Ok(dir_entry) = dir_entry else {
-            debug!("Unable to read directory entry");
-            continue;
-        };
-        let path = dir_entry.path();
-        if !path.exists() {
-            continue;
-        }
-        if path.is_file() {
-            // trim root path from the file path
-            let relative_path = path.strip_prefix(root_path).unwrap_or(&path);
-            files.push(ScanInfo::new(
-                relative_path.to_string_lossy().to_string(),
-                modified_time_ms(&path),
-                created_time_ms(&path),
-            ));
-        } else if path.is_dir() {
-            scan_dir_recursively(files, &path, root_path);
-        }
-    }
-}
-
-fn modified_time_ms(path: &Path) -> Option<i64> {
-    path.metadata()
-        .ok()
-        .and_then(|m| m.modified().ok())
-        .and_then(|dt| {
-            dt.duration_since(SystemTime::UNIX_EPOCH)
-                .ok()
-                .map(|d| d.as_millis() as i64)
-        })
-}
-
-fn created_time_ms(path: &Path) -> Option<i64> {
-    path.metadata()
-        .ok()
-        .and_then(|m| m.created().ok())
-        .and_then(|dt| {
-            dt.duration_since(SystemTime::UNIX_EPOCH)
-                .ok()
-                .map(|d| d.as_millis() as i64)
-        })
-}
-
-impl PsContainer for PsDirectoryContainer {
-    fn scan(&self) -> Vec<ScanInfo> {
-        let mut files = Vec::new();
-        let root_path = Path::new(&self.root);
-        if !root_path.exists() {
-            debug!("Root path does not exist: {root_path:?}");
-            return files;
-        }
-        if !root_path.is_dir() {
-            debug!("Root path is not a directory: {root_path:?}");
-            return files;
-        }
-        scan_dir_recursively(&mut files, root_path, root_path);
-        files
-    }
-    fn file_bytes(&mut self, path: &str) -> anyhow::Result<Vec<u8>> {
-        let file_path = Path::new(&self.root).join(path);
-        let file_r = File::open(&file_path);
-        let Ok(mut file) = file_r else {
-            debug!("Unable to open file: {file_path:?}");
-            return Err(anyhow!("Unable to open file {file_path:?}"));
-        };
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap_or(0);
-        Ok(buffer)
-    }
-
-    fn file_reader(&mut self, path: &str) -> anyhow::Result<Box<dyn ReadSeek>> {
-        let file_path = Path::new(&self.root).join(path);
-        let file_r = File::open(&file_path);
-        let Ok(file) = file_r else {
-            warn!("Unable to open file: {file_path:?}");
-            return Err(anyhow!("Unable to open file {file_path:?}"));
-        };
-        Ok(Box::new(file))
-    }
-
-    fn exists(&self, file: &str) -> bool {
-        Path::new(&self.root).join(file).exists()
-    }
-    fn root_exists(&self) -> bool {
-        Path::new(&self.root).exists()
-    }
-}
-
-pub(crate) struct PsZipContainer {
-    zip_file: String,
-    index: Vec<ScanInfo>,
-    zip: ZipArchive<File>,
-    tz: chrono::FixedOffset,
-}
-
-impl PsZipContainer {
-    pub(crate) fn new(zip_file: &String, tz: chrono::FixedOffset) -> Self {
-        let z = ZipArchive::new(File::open(zip_file.clone()).unwrap());
-        let mut c = PsZipContainer {
-            zip_file: zip_file.to_string(),
-            index: vec![],
-            zip: z.unwrap(),
-            tz,
-        };
-        c.index();
-        c
-    }
-    fn index(&mut self) {
-        let zip_archive = &mut self.zip;
-        for i in 0..zip_archive.len() {
-            let file_res = zip_archive.by_index(i);
-            let Some(file_in_zip) = file_res.ok() else {
-                continue;
-            };
-            if file_in_zip.is_dir() {
-                continue;
-            }
-            let Some(enclosed_name) = file_in_zip.enclosed_name() else {
-                continue;
-            };
-            let p = enclosed_name.as_path();
-            let file_name_o = p.to_str();
-            let Some(file_name) = file_name_o else {
-                continue;
-            };
-            let mut dt_o = None;
-            if let Some(lm) = file_in_zip.last_modified() {
-                // not zip dates are dodgy, see zip crate's docs
-                // zip times don't include tz, blindly assume they are in the local tz
-                dt_o = chrono::NaiveDate::from_ymd_opt(
-                    lm.year() as i32,
-                    lm.month() as u32,
-                    lm.day() as u32,
-                )
-                .and_then(|date| date.and_hms_opt(lm.hour() as u32, lm.minute() as u32, 0))
-                .and_then(|naive_dt| naive_dt.and_local_timezone(self.tz).single())
-                .map(|dt| dt.timestamp_millis());
-            }
-            self.index
-                .push(ScanInfo::new(file_name.to_string(), dt_o, None));
-        }
-        debug!(
-            "Counted {} files in zip {:?}",
-            self.index.len(),
-            self.zip_file
-        );
-    }
-}
-
-impl PsContainer for PsZipContainer {
-    fn scan(&self) -> Vec<ScanInfo> {
-        self.index.clone()
-    }
-    fn file_bytes(&mut self, path: &str) -> anyhow::Result<Vec<u8>> {
-        let file_res = self.zip.by_name(path);
-        let Some(mut file) = file_res.ok() else {
-            warn!("Unable to open file: {path:?}");
-            return Err(anyhow!("Unable to find file {:?}", path));
-        };
-        if file.is_dir() {
-            warn!("Attempted roe read bytes from a directory: {path:?}");
-            return Err(anyhow!("File is a dir {:?}", path));
-        }
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap_or(0);
-        Ok(buffer)
-    }
-
-    fn file_reader(&mut self, path: &str) -> anyhow::Result<Box<dyn ReadSeek>> {
-        let bytes = self.file_bytes(path)?;
-        Ok(Box::new(Cursor::new(bytes)))
-    }
-
-    fn exists(&self, path: &str) -> bool {
-        self.index.iter().any(|i| i.file_path.eq(path))
-    }
-    fn root_exists(&self) -> bool {
-        Path::new(&self.zip_file).exists()
-    }
+    scan_infos
 }
 
 pub(crate) fn is_existing_file_same(
-    output_container: &mut PsDirectoryContainer,
+    fs: &mut OsFileSystem,
     long_checksum: &str,
     output_path: &String,
 ) -> Option<bool> {
-    let Ok(reader) = output_container.file_reader(output_path) else {
+    let Ok(reader) = fs.open(output_path) else {
         debug!("Could not read file bytes for checksum: {output_path:?}");
         return None;
     };
@@ -373,20 +119,19 @@ mod tests {
     fn test_zip() -> anyhow::Result<()> {
         crate::test_util::setup_log();
         let tz = chrono::FixedOffset::east_opt(0).unwrap();
-        let c = PsZipContainer::new(&"test/Canon_40D.jpg.zip".to_string(), tz);
-        let index = c.scan();
+        let mut c = ZipFileSystem::new("test/Canon_40D.jpg.zip", tz)?;
+        let index = scan_fs(&mut c);
         assert_eq!(index.len(), 2);
-        let si = index.first().unwrap();
-        assert_eq!(si.file_path, "Canon_40D.jpg");
+        // Find Canon_40D.jpg
+        let si = index.iter().find(|i| i.file_path == "Canon_40D.jpg").unwrap();
         assert_eq!(si.modified_datetime, Some(1749917340000));
         Ok(())
     }
 
     #[test]
     fn test_files_checksum() -> anyhow::Result<()> {
-        use crate::util::PsDirectoryContainer;
-        let mut c = PsDirectoryContainer::new(&"test".to_string());
-        let b = c.file_reader("Canon_40D.jpg")?;
+        let mut c = OsFileSystem::new("test");
+        let b = c.open("Canon_40D.jpg")?;
         let csm = checksum_bytes(b)?;
         assert_eq!(csm.short_checksum, "6bfdabd".to_string());
         assert_eq!(


### PR DESCRIPTION
Replaced ad-hoc `PsContainer` trait with a more standard `FileSystem` trait supporting `OsFileSystem` and `ZipFileSystem`.
This refactoring separates file system access (open, exists, walk, metadata) from scanning logic (ScanInfo).
Updated all call sites to use the new trait.
Verified with existing tests.

---
*PR created automatically by Jules for task [998093628846328615](https://jules.google.com/task/998093628846328615) started by @paultuckey*