### PR TITLE
Multithreaded db command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +400,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -754,6 +785,7 @@ dependencies = [
  "file-format",
  "hex",
  "nom-exif",
+ "rayon",
  "regex",
  "rusqlite",
  "serde",
@@ -814,6 +846,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ strum_macros = "0.27"
 rusqlite = { version = "0.38", features = ["bundled"] }
 nom-exif = "2.6"
 hex = "0.4"
+rayon = "1.11.0"

--- a/src/exif_util.rs
+++ b/src/exif_util.rs
@@ -140,7 +140,7 @@ mod tests {
     #[test]
     fn test_parse_exif_mp4() -> anyhow::Result<()> {
         crate::test_util::setup_log();
-        let mut c = OsFileSystem::new(&"test".to_string());
+        let c = OsFileSystem::new(&"test".to_string());
         let reader = c.open(&"Hello.mp4".to_string())?;
         let t = parse_exif_info(reader);
         assert_eq!(t.is_none(), true);
@@ -150,7 +150,7 @@ mod tests {
     #[test]
     fn test_parse_exif_all_tags() -> anyhow::Result<()> {
         crate::test_util::setup_log();
-        let mut c = OsFileSystem::new("test");
+        let c = OsFileSystem::new("test");
         let reader = c.open("Canon_40D.jpg")?;
         let t = parse_exif_info(reader).unwrap().tags;
         assert_eq!(t.len(), 40);

--- a/src/file_type.rs
+++ b/src/file_type.rs
@@ -165,7 +165,7 @@ mod tests {
         crate::test_util::setup_log();
         use crate::fs::OsFileSystem;
         let name = "Canon_40D.jpg".to_string();
-        let mut root = OsFileSystem::new(&"test".to_string());
+        let root = OsFileSystem::new(&"test".to_string());
         let r = root.open(&name).unwrap();
         assert_eq!(determine_file_type(r, &name), AccurateFileType::Jpg);
 

--- a/src/index_cmd.rs
+++ b/src/index_cmd.rs
@@ -27,7 +27,7 @@ pub(crate) fn main(input: &String) -> anyhow::Result<()> {
     if !path.exists() {
         return Err(anyhow!("Input path does not exist: {}", input));
     }
-    let mut container: Box<dyn FileSystem> = if path.is_dir() {
+    let container: Box<dyn FileSystem> = if path.is_dir() {
         info!("Input directory: {input}");
         Box::new(OsFileSystem::new(input))
     } else {
@@ -35,7 +35,7 @@ pub(crate) fn main(input: &String) -> anyhow::Result<()> {
         let tz = chrono::Local::now().offset().to_owned();
         Box::new(ZipFileSystem::new(input, tz)?)
     };
-    let idx = scan_fs(container.as_mut());
+    let idx = scan_fs(container.as_ref());
 
     let mut distinct_dirs: HashSet<String> = HashSet::new();
     for si in &idx {

--- a/src/media.rs
+++ b/src/media.rs
@@ -4,7 +4,7 @@ use crate::file_type::{
     AccurateFileType, MetadataType, QuickFileType, determine_file_type, file_ext_from_file_type,
     metadata_type,
 };
-use crate::fs::{FileSystem, OsFileSystem};
+use crate::fs::FileSystem;
 use crate::supplemental_info::PsSupplementalInfo;
 use crate::track_util::{PsTrackInfo, parse_track_info};
 use crate::util::ScanInfo;
@@ -39,7 +39,7 @@ pub(crate) struct MediaFileDerivedInfo {
 
 pub(crate) fn media_file_info_from_readable(
     si: &ScanInfo,
-    root: &mut Box<dyn FileSystem>,
+    root: &dyn FileSystem,
     supp_info: &Option<PsSupplementalInfo>,
     hash_info: &HashInfo,
 ) -> anyhow::Result<MediaFileInfo> {
@@ -182,6 +182,7 @@ pub(crate) fn get_desired_media_path(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fs::OsFileSystem;
 
     #[test]
     fn test_best_guess_taken_dt_timestamps() {
@@ -207,7 +208,7 @@ mod tests {
         crate::test_util::setup_log();
         use crate::util::checksum_bytes;
 
-        let mut c = OsFileSystem::new(&"test".to_string());
+        let c = OsFileSystem::new(&"test".to_string());
         let reader = c.open(&"Canon_40D.jpg".to_string()).unwrap();
         let short_checksum = checksum_bytes(reader)?.short_checksum;
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,15 +1,17 @@
 use status_line::StatusLine;
 use std::fmt::{Display, Formatter};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
+#[derive(Clone)]
 pub(crate) struct Progress {
     total: u64,
-    current: AtomicU64,
+    current: Arc<AtomicU64>,
 }
 impl Progress {
     pub(crate) fn new(total: u64) -> StatusLine<Progress> {
         StatusLine::new(Progress {
-            current: AtomicU64::new(0),
+            current: Arc::new(AtomicU64::new(0)),
             total,
         })
     }
@@ -66,7 +68,7 @@ mod tests {
     fn test_display_basic() {
         // 0%
         let p = Progress {
-            current: AtomicU64::new(0),
+            current: Arc::new(AtomicU64::new(0)),
             total: 100,
         };
         assert_eq!(
@@ -76,7 +78,7 @@ mod tests {
 
         // 50%
         let p = Progress {
-            current: AtomicU64::new(50),
+            current: Arc::new(AtomicU64::new(50)),
             total: 100,
         };
         // 19 * 50 / 100 = 9.5 -> 9
@@ -91,7 +93,7 @@ mod tests {
 
         // 100%
         let p = Progress {
-            current: AtomicU64::new(100),
+            current: Arc::new(AtomicU64::new(100)),
             total: 100,
         };
         // pos=19
@@ -106,7 +108,7 @@ mod tests {
     #[test]
     fn test_display_zero_total() {
         let p = Progress {
-            current: AtomicU64::new(0),
+            current: Arc::new(AtomicU64::new(0)),
             total: 0,
         };
         // Should handle total=0 gracefully (0% progress)
@@ -119,7 +121,7 @@ mod tests {
     #[test]
     fn test_display_overflow() {
         let p = Progress {
-            current: AtomicU64::new(150),
+            current: Arc::new(AtomicU64::new(150)),
             total: 100,
         };
         // Should cap at 100% visual progress

--- a/src/supplemental_info.rs
+++ b/src/supplemental_info.rs
@@ -5,7 +5,7 @@ use tracing::{debug, warn};
 
 pub(crate) fn detect_supplemental_info(
     path: &String,
-    container: &mut Box<dyn FileSystem>,
+    container: &dyn FileSystem,
 ) -> Option<String> {
     let google_supp_json_exts = vec![
         ".supplemental-metadata.json",
@@ -23,7 +23,7 @@ pub(crate) fn detect_supplemental_info(
 
 pub(crate) fn load_supplemental_info(
     path: &String,
-    container: &mut Box<dyn FileSystem>,
+    container: &dyn FileSystem,
 ) -> Option<PsSupplementalInfo> {
     let reader_r = container.open(path);
     let Ok(reader) = reader_r else {

--- a/src/track_util.rs
+++ b/src/track_util.rs
@@ -97,7 +97,7 @@ mod tests {
     #[test]
     fn test_parse_track() -> anyhow::Result<()> {
         crate::test_util::setup_log();
-        let mut c = OsFileSystem::new(&"test".to_string());
+        let c = OsFileSystem::new(&"test".to_string());
         let reader = c.open(&"Hello.mp4".to_string())?;
         let meta = parse_track_info(reader).unwrap();
         assert_eq!(meta.width, Some(854));
@@ -115,8 +115,8 @@ mod tests {
     #[ignore]
     fn test_all_mp4s() -> anyhow::Result<()> {
         crate::test_util::setup_log();
-        let mut c = OsFileSystem::new(&"input".to_string());
-        for si in scan_fs(&mut c) {
+        let c = OsFileSystem::new(&"input".to_string());
+        for si in scan_fs(&c) {
             let path = Path::new(&si.file_path);
             if path
                 .extension()


### PR DESCRIPTION
This PR adds multithreading to the `db` command to speed up file scanning and processing.

Key changes:
1.  **Thread-Safe FileSystem**: The `FileSystem` trait now requires `Send + Sync` and uses `&self` for operations like `open`. `ZipFileSystem` uses a `Mutex` to serialize access to the underlying `ZipArchive` while allowing concurrent access to the `FileSystem` wrapper.
2.  **Parallel Processing**: The `db` command uses `rayon` to process files in parallel. CPU-intensive tasks like SHA256 checksum calculation and metadata parsing (EXIF, JSON) are offloaded to worker threads.
3.  **Pipeline Architecture**: A `std::sync::mpsc` channel connects the parallel workers (producers) to a serial database writer (consumer). This ensures efficient resource usage while avoiding SQLite locking issues.
4.  **Refactoring**: Updated usages of `FileSystem` across the codebase (`sync`, `index`, `info` commands) to align with the new thread-safe API.

Performance: Parallel processing significantly reduces the time to scan and index large collections of photos, especially when IO is not the bottleneck (e.g., cached files or fast SSDs). For Zip files, IO is serialized but CPU work is still parallelized.

---
*PR created automatically by Jules for task [5664879927946003529](https://jules.google.com/task/5664879927946003529) started by @paultuckey*