### PR TITLE
⚡ Optimize deduplication with file size check

### DIFF
--- a/src/album.rs
+++ b/src/album.rs
@@ -205,7 +205,7 @@ mod tests {
     fn test_ic_sample() -> anyhow::Result<()> {
         crate::test_util::setup_log();
         let c = OsFileSystem::new(&"test".to_string());
-        let qsf = ScanInfo::new("ic-album-sample.csv".to_string(), None, None);
+        let qsf = ScanInfo::new("ic-album-sample.csv".to_string(), None, None, 0);
         let a = parse_album(&c, &qsf, &vec![]).unwrap();
         assert_eq!(a.title, "ic-album-sample".to_string());
         assert_eq!(a.files.len(), 5);
@@ -220,9 +220,9 @@ mod tests {
     fn test_g_sample() -> anyhow::Result<()> {
         crate::test_util::setup_log();
         let c = OsFileSystem::new(&"test/takeout1".to_string());
-        let qsf = ScanInfo::new("Google Photos/album1/metadata.json".to_string(), None, None);
-        let si1 = ScanInfo::new("Google Photos/album1/test1.jpg".to_string(), None, None);
-        let si2 = ScanInfo::new("different/test2.jpg".to_string(), None, None);
+        let qsf = ScanInfo::new("Google Photos/album1/metadata.json".to_string(), None, None, 0);
+        let si1 = ScanInfo::new("Google Photos/album1/test1.jpg".to_string(), None, None, 0);
+        let si2 = ScanInfo::new("different/test2.jpg".to_string(), None, None, 0);
         let a = parse_album(&c, &qsf, &vec![si1, si2]).unwrap();
         assert_eq!(a.title, "Some album title".to_string());
         assert_eq!(a.files.len(), 1);

--- a/src/info_cmd.rs
+++ b/src/info_cmd.rs
@@ -14,7 +14,8 @@ use tracing::{debug, warn};
 pub(crate) fn main(input: &String, root_s: &str) -> anyhow::Result<()> {
     debug!("Inspecting: {input}");
     let root: Box<dyn FileSystem> = Box::new(OsFileSystem::new(root_s));
-    let si = ScanInfo::new(input.clone(), None, None);
+    let len = root.metadata(input).map(|m| m.len).unwrap_or(0);
+    let si = ScanInfo::new(input.clone(), None, None, len);
     match si.quick_file_type {
         QuickFileType::Unknown => {
             warn!("File type is unknown, skipping: {input}");

--- a/src/media.rs
+++ b/src/media.rs
@@ -27,6 +27,7 @@ pub(crate) struct MediaFileInfo {
     // Modified time of the file
     pub(crate) modified: Option<i64>,
     pub(crate) created: Option<i64>,
+    pub(crate) file_size: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -77,6 +78,7 @@ pub(crate) fn media_file_info_from_readable(
         supp_info: supp_info.clone(),
         modified: si.modified_datetime,
         created: si.created_datetime,
+        file_size: si.file_size,
     };
     Ok(media_file_info)
 }
@@ -248,6 +250,7 @@ impl MediaFileInfo {
             supp_info: None,
             modified: None,
             created: None,
+            file_size: 0,
         }
     }
 }

--- a/src/sync_cmd.rs
+++ b/src/sync_cmd.rs
@@ -254,6 +254,7 @@ fn get_de_duplicated_path(
             output_container,
             long_checksum,
             &desired_output_path_with_ext,
+            Some(media_file.file_size),
         );
         match es_o {
             Some(true) => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -36,6 +36,7 @@ pub(crate) struct ScanInfo {
     /// Unix Epoch time file creation
     pub(crate) created_datetime: Option<i64>,
     pub(crate) quick_file_type: QuickFileType,
+    pub(crate) file_size: u64,
 }
 
 impl ScanInfo {
@@ -43,6 +44,7 @@ impl ScanInfo {
         file_path: String,
         modified_datetime: Option<i64>,
         created_datetime: Option<i64>,
+        file_size: u64,
     ) -> Self {
         let quick_file_type = find_quick_file_type(&file_path);
         ScanInfo {
@@ -50,6 +52,7 @@ impl ScanInfo {
             modified_datetime,
             created_datetime,
             quick_file_type,
+            file_size,
         }
     }
 }
@@ -59,11 +62,11 @@ pub(crate) fn scan_fs(fs: &dyn FileSystem) -> Vec<ScanInfo> {
     let mut scan_infos = Vec::new();
     for path in paths {
         let meta = fs.metadata(&path).ok();
-        let (mod_dt, create_dt) = match meta {
-            Some(m) => (m.modified, m.created),
-            None => (None, None),
+        let (mod_dt, create_dt, len) = match meta {
+            Some(m) => (m.modified, m.created, m.len),
+            None => (None, None, 0),
         };
-        scan_infos.push(ScanInfo::new(path, mod_dt, create_dt));
+        scan_infos.push(ScanInfo::new(path, mod_dt, create_dt, len));
     }
     scan_infos
 }
@@ -72,7 +75,20 @@ pub(crate) fn is_existing_file_same(
     fs: &OsFileSystem,
     long_checksum: &str,
     output_path: &String,
+    expected_file_size: Option<u64>,
 ) -> Option<bool> {
+    if let Some(expected_size) = expected_file_size {
+        if let Ok(metadata) = fs.metadata(output_path) {
+            if metadata.len != expected_size {
+                debug!(
+                    "File size mismatch for {output_path:?}. Expected {expected_size}, found {}",
+                    metadata.len
+                );
+                return Some(false);
+            }
+        }
+    }
+
     let Ok(reader) = fs.open(output_path) else {
         debug!("Could not read file bytes for checksum: {output_path:?}");
         return None;
@@ -137,5 +153,48 @@ mod tests {
             "6bfdabd4fc33d112283c147acccc574e770bbe6fbdbc3d4da968ba7b606ecc2f".to_string()
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod performance_tests {
+    use super::*;
+    use crate::fs::OsFileSystem;
+    use std::fs::File;
+    use std::io::Write;
+    use std::time::Instant;
+
+    #[test]
+    #[ignore]
+    fn test_performance_is_existing_file_same() {
+        let test_dir = "test_perf_output";
+        std::fs::create_dir_all(test_dir).unwrap();
+        let file_path = format!("{}/large_file.dat", test_dir);
+
+        // Create a 50MB file
+        let mut file = File::create(&file_path).unwrap();
+        let data =vec![0u8; 50 * 1024 * 1024];
+        file.write_all(&data).unwrap();
+
+        let fs = OsFileSystem::new(test_dir);
+        let start = Instant::now();
+
+        // Check with a fake checksum
+        let res = is_existing_file_same(
+            &fs,
+            "fakechecksum",
+            &"large_file.dat".to_string(),
+            Some(12345),
+        );
+        assert_eq!(res, Some(false));
+
+        let duration = start.elapsed();
+        println!("Time taken: {:?}", duration);
+
+        // Cleanup
+        std::fs::remove_dir_all(test_dir).unwrap();
+
+        // Assert that it was fast (optimization works)
+        assert!(duration.as_millis() < 10, "Should be instant due to size check optimization");
     }
 }


### PR DESCRIPTION
This PR implements a performance optimization for file deduplication. By checking the file size of the existing file against the expected file size (from `ScanInfo`), we can avoid reading and hashing the entire file if the sizes differ. This is a significant improvement for scenarios where files are different, especially for large files.

The changes include:
- Modifying `ScanInfo` and `MediaFileInfo` to carry `file_size`.
- Updating `scan_fs` to extract file size from metadata.
- Modifying `is_existing_file_same` to accept `expected_file_size` and perform the check.
- Updating `get_de_duplicated_path` to use the new optimization.
- A regression/performance test in `src/util.rs` demonstrating the speedup.

---
*PR created automatically by Jules for task [7306005422840151504](https://jules.google.com/task/7306005422840151504) started by @paultuckey*