### PR TITLE
Support albums in database scan

### DIFF
--- a/src/album.rs
+++ b/src/album.rs
@@ -146,7 +146,7 @@ fn parse_json_album(
 pub(crate) struct Album {
     pub(crate) desired_album_md_path: String,
     pub(crate) title: String,
-    files: Vec<String>,
+    pub(crate) files: Vec<String>,
 }
 
 pub(crate) fn build_album_md(


### PR DESCRIPTION
This change extends the `db` command to support scanning and storing album metadata. It introduces `album` and `album_file` tables to the SQLite database. The scanning logic now identifies album files (CSV from iCloud or JSON from Google Takeout), parses them, and populates the database with album titles and file paths. A new integration test verifies this functionality.

---
*PR created automatically by Jules for task [12465771409964870751](https://jules.google.com/task/12465771409964870751) started by @paultuckey*